### PR TITLE
Update users.yml

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,9 +1,10 @@
 ---
 - name: Ensure PostgreSQL users are present.
   postgresql_user:
-    name: "{{ item.name }}"
-    password: "{{ item.password | default(omit) }}"
-  with_items: "{{ postgresql_users }}"
+    name: "{{ item.0.name }}"
+    password: "{{ item.0.password | default(omit) }}"
+    login_unix_socket: "{{ item.1 }}"
+  loop: "{{ postgresql_users|zip(postgresql_unix_socket_directories) | list }}"
   no_log: "{{ postgres_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"


### PR DESCRIPTION
If the default dir in postgresql_unix_socket_directories was changed the uses could not be created. This fix loops over the sockes (if more than standard 1) and add uses from /with all sockets